### PR TITLE
Target RxJS v6.0.0-alpha.3 or greater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
     - "node_modules"
 before_install:
-  - "npm install axios rxjs"
+  - "npm install axios rxjs@alpha"
 after_success:
   - "npm run build"
   - "npm run semantic-release"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Rxios makes the awesome [axios](https://github.com/axios/axios) library reactive, so that it's responses are returned as [RxJS](https://github.com/ReactiveX/rxjs) observables.
 
+## RxJS 6 Alpha
+
+Note that this version of Rxios is built against [RxJS 6 Alpha 3](https://github.com/ReactiveX/rxjs#rxjs-6-alpha) or greater as a peer dependency. Breaking changes might occur, both in Rxios and RxJS.
+
 ### Observables? Why?
 
 Regular promises are cool, especially for HTTP requests in async/await functions.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/davguij/rxios#readme",
   "peerDependencies": {
     "axios": "~0.17.0",
-    "rxjs": "^5.0.0"
+    "rxjs": ">=6.0.0-alpha.3 <7.0.0"
   },
   "devDependencies": {
     "@types/jest": "^21.1.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosPromise } from 'axios';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 
 export interface rxiosConfig extends AxiosRequestConfig {
   localCache?: boolean;


### PR DESCRIPTION
- The next version of RxJS is in alpha; `npm install rxjs@alpha`.
- RxJS v6 has breaking changes in the way classes are imported.
- This fixes importing the `Observable` class.
- Added a note in the readme regarding using an alpha peer dependency.
- It might not be necessary to incorporate the changes into Rxios until RxJS v6 is stable, unless also following the `npm install rxios@alpha` pattern.

See

- https://github.com/ReactiveX/rxjs#rxjs-6-alpha