### PR TITLE
fix: include Rxios alias

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ cache:
   directories:
     - "node_modules"
 before_install:
-  - "npm install axios rxjs"
+  - "npm install axios@0.17 rxjs"
+script:
+  - "npm test -- -w=2"
 after_script:
   - "npm run build"
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ node_js:
 cache:
   directories:
     - "node_modules"
-before_install:
-  - "npm install axios@0.17 rxjs"
+before_script:
+  - "npm install --no-save axios@0.17 rxjs"
 script:
   - "npm test -- -w=2"
-after_script:
-  - "npm run build"
 after_success:
+  - "npm run build"
   - "npm run semantic-release"

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -1,51 +1,95 @@
-import { rxios } from '../src';
+jest.setTimeout(20000);
+
+import { rxios, Rxios } from '../src';
 import * as nock from 'nock';
 
 const mockServer = nock('http://test.com');
 
+describe('Instantiation', () => {
+  let rxiosInstance: rxios;
+
+  afterEach(() => {
+    rxiosInstance = null;
+  });
+
+  it('works with new rxios()', () => {
+    rxiosInstance = new rxios({
+      baseURL: 'http://test.com/',
+    });
+    expect(rxiosInstance).toBeInstanceOf(rxios);
+  });
+
+  it('also works with new Rxios()', () => {
+    rxiosInstance = new Rxios({
+      baseURL: 'http://test.com/',
+    });
+    expect(rxiosInstance).toBeInstanceOf(rxios);
+  });
+});
+
 describe('GET method', () => {
   let rxiosInstance: rxios;
-  
+
   beforeEach(() => {
     rxiosInstance = new rxios({
-      baseURL: 'http://test.com/'
+      baseURL: 'http://test.com/',
     });
+  });
+
+  afterEach(() => {
+    rxiosInstance = null;
   });
 
   it('makes a successful GET req', async () => {
     const expected = { id: 1, title: 'rxios is so cool!', author: 'davguij' };
     mockServer.get('/posts/1').reply(200, expected);
     const promise = new Promise((resolve, reject) => {
-      rxiosInstance.get('http://test.com/posts/1').subscribe(resp => {
-        resolve(resp);
-      }, err => {
-        reject(err);
-      });  
+      rxiosInstance.get('http://test.com/posts/1').subscribe(
+        resp => {
+          resolve(resp);
+        },
+        err => {
+          reject(err);
+        }
+      );
     });
     await expect(promise).resolves.toEqual(expected);
   });
 
   it('throws an error on a failed GET req', async () => {
-    mockServer.get('/posts/1').replyWithError('Request failed with status code 500');
+    mockServer
+      .get('/posts/1')
+      .replyWithError('Request failed with status code 500');
 
     const promise = new Promise((resolve, reject) => {
-      rxiosInstance.get('http://test.com/posts/1').subscribe(resp => {
-        resolve(resp);
-      }, err => {
-        reject(err);
-      });  
+      rxiosInstance.get('http://test.com/posts/1').subscribe(
+        resp => {
+          resolve(resp);
+        },
+        err => {
+          reject(err);
+        }
+      );
     });
     await expect(promise).rejects.toBeInstanceOf(Error);
   });
 
   it('accepts queryParams', async () => {
-    mockServer.get('/posts').query({title: 'rxios', author: 'davguij'}).reply(200);
+    mockServer
+      .get('/posts')
+      .query({ title: 'rxios', author: 'davguij' })
+      .reply(200);
     const promise = new Promise((resolve, reject) => {
-      rxiosInstance.get('http://test.com/posts', {title: 'rxios', author: 'davguij'}).subscribe(resp => {
-        resolve(resp);
-      }, err => {
-        reject(err);
-      })
+      rxiosInstance
+        .get('http://test.com/posts', { title: 'rxios', author: 'davguij' })
+        .subscribe(
+          resp => {
+            resolve(resp);
+          },
+          err => {
+            reject(err);
+          }
+        );
     });
     await expect(promise).resolves.toBeDefined();
   });
@@ -53,78 +97,98 @@ describe('GET method', () => {
   it('accepts a type for the response', async () => {
     interface i {
       cool: boolean;
-    };
+    }
 
-    const response: i = {cool: true};
-  
+    const response: i = { cool: true };
+
     mockServer.get('/post/1').reply(200, response);
     const promise = new Promise((resolve, reject) => {
-      rxiosInstance.get<i>('http://test.com/post/1').subscribe(resp => {
-        resolve(resp);
-      }, err => {
-        reject(err);
-      })
+      rxiosInstance.get<i>('http://test.com/post/1').subscribe(
+        resp => {
+          resolve(resp);
+        },
+        err => {
+          reject(err);
+        }
+      );
     });
     await expect(promise).resolves.toBeDefined();
   });
-
 });
 
 describe('POST method', () => {
   let rxiosInstance: rxios;
-  
+
   beforeEach(() => {
     rxiosInstance = new rxios({
-      baseURL: 'http://test.com/'
+      baseURL: 'http://test.com/',
     });
+  });
+
+  afterEach(() => {
+    rxiosInstance = null;
   });
 
   it('makes a successful POST req', async () => {
     mockServer.post('/posts').reply(201);
     const body = { title: 'json-server', author: 'davguij' };
     const promise = new Promise((resolve, reject) => {
-      rxiosInstance.post('posts', body).subscribe(resp => {
-        resolve(resp);
-      }, err => {
-        reject(err);
-      })
+      rxiosInstance.post('posts', body).subscribe(
+        resp => {
+          resolve(resp);
+        },
+        err => {
+          reject(err);
+        }
+      );
     });
     await expect(promise).resolves.toBeDefined();
   });
 
   it('throws an error on a failed POST req', async () => {
-    mockServer.post('/posts').replyWithError('Request failed with status code 500');
+    mockServer
+      .post('/posts')
+      .replyWithError('Request failed with status code 500');
 
     const promise = new Promise((resolve, reject) => {
-      rxiosInstance.post('http://test.com/posts', {}).subscribe(resp => {
-        resolve(resp);
-      }, err => {
-        reject(err);
-      });  
+      rxiosInstance.post('http://test.com/posts', {}).subscribe(
+        resp => {
+          resolve(resp);
+        },
+        err => {
+          reject(err);
+        }
+      );
     });
     await expect(promise).rejects.toBeInstanceOf(Error);
   });
 });
 
-
 describe('rest of methods', () => {
   let rxiosInstance: rxios;
-  
+
   beforeEach(() => {
     rxiosInstance = new rxios({
-      baseURL: 'http://test.com/'
+      baseURL: 'http://test.com/',
     });
+  });
+
+  afterEach(() => {
+    rxiosInstance = null;
   });
 
   it('makes a successful PUT req', async () => {
     const body = { title: 'json-server', author: 'davguij' };
     mockServer.put('/post/1').reply(200, body);
     const promise = new Promise((resolve, reject) => {
-      rxiosInstance.put('post/1', body).subscribe(resp => {
-        resolve(resp);
-      }, err => {
-        reject(err);
-      })
+      rxiosInstance.put('post/1', body).subscribe(
+        resp => {
+          resolve(resp);
+        },
+        err => {
+          reject(err);
+        }
+      );
     });
     await expect(promise).resolves.toEqual(body);
   });
@@ -133,11 +197,14 @@ describe('rest of methods', () => {
     const body = { title: 'json-server', author: 'davguij' };
     mockServer.patch('/post/1').reply(200, body);
     const promise = new Promise((resolve, reject) => {
-      rxiosInstance.patch('post/1', body).subscribe(resp => {
-        resolve(resp);
-      }, err => {
-        reject(err);
-      })
+      rxiosInstance.patch('post/1', body).subscribe(
+        resp => {
+          resolve(resp);
+        },
+        err => {
+          reject(err);
+        }
+      );
     });
     await expect(promise).resolves.toEqual(body);
   });
@@ -145,13 +212,15 @@ describe('rest of methods', () => {
   it('makes a successful DELETE req', async () => {
     mockServer.delete('/post/1').reply(200);
     const promise = new Promise((resolve, reject) => {
-      rxiosInstance.delete('post/1').subscribe(resp => {
-        resolve(resp);
-      }, err => {
-        reject(err);
-      })
+      rxiosInstance.delete('post/1').subscribe(
+        resp => {
+          resolve(resp);
+        },
+        err => {
+          reject(err);
+        }
+      );
     });
     await expect(promise).resolves.toBeDefined();
   });
-
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rxios",
-  "version": "1.0.0",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -252,15 +252,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
-    },
-    "axios": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-      "requires": {
-        "follow-redirects": "1.2.6",
-        "is-buffer": "1.1.6"
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1126,6 +1117,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
       "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
+      "dev": true,
       "requires": {
         "debug": "3.1.0"
       },
@@ -1134,6 +1126,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2349,7 +2342,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3209,7 +3203,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "nan": {
       "version": "2.8.0",
@@ -3811,14 +3806,6 @@
         "glob": "7.1.2"
       }
     },
-    "rxjs": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
-      "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
-      "requires": {
-        "symbol-observable": "1.0.4"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -4085,11 +4072,6 @@
       "requires": {
         "has-flag": "2.0.0"
       }
-    },
-    "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export interface rxiosConfig extends AxiosRequestConfig {
   localCache?: boolean;
 }
 
-export class rxios {
+class rxios {
   private _httpClient: AxiosInstance;
   
   constructor(private options: rxiosConfig = {}) {
@@ -65,3 +65,5 @@ export class rxios {
     return this._makeRequest('DELETE', url, queryParams);
   }
 }
+
+export {rxios, rxios as Rxios};


### PR DESCRIPTION
Added an alias so that the class can be instantiated with both `new rxios()` and `new Rxios()`. 

Should help with linting errors.

Fixes #1.